### PR TITLE
Added missing public $jid to XMPP Connection.php

### DIFF
--- a/PHPDaemon/Clients/XMPP/Connection.php
+++ b/PHPDaemon/Clients/XMPP/Connection.php
@@ -44,7 +44,12 @@ class Connection extends ClientConnection {
 	 * @var string
 	 */
 	public $fulljid;
-	
+
+        /**
+         * @var string
+         */
+        public $jid;
+
 	/**
 	 * @var integer|string Timer ID
 	 */


### PR DESCRIPTION
Fixes an error using xmpp client: 

[PHPD] [CODE WARN] Setting undefined property "jid" in object of class PHPDaemon\Clients\XMPP\Connection
